### PR TITLE
Speedup binary stl writes using larger buffer size of 25kB

### DIFF
--- a/writer.go
+++ b/writer.go
@@ -36,51 +36,51 @@ func WriteASCII(w io.Writer, t []Triangle) error {
 
 // Write writes the triangle mesh to the writer using binary STL codec.
 func WriteBinary(w io.Writer, t []Triangle) error {
-	var err error
-	twoZeroes := make([]byte, 2)
-	wr := func(data []byte) {
-		if err != nil {
-			return
-		}
-		_, err = w.Write(data)
-	}
-	bwr := func(v interface{}) {
-		if err != nil {
-			return
-		}
-		err = binary.Write(w, binary.LittleEndian, v)
-	}
-	f32w := func(f float32) {
-		if err != nil {
-			return
-		}
-		err = binary.Write(w, binary.LittleEndian, math.Float32bits(f))
-	}
-	pwr := func(p Point) {
-		if err != nil {
-			return
-		}
-		f32w(p[0])
-		f32w(p[1])
-		f32w(p[2])
+	headerBuf := make([]byte, 84)
+
+	// Write triangle count
+	binary.LittleEndian.PutUint32(headerBuf[80:84], uint32(len(t)))
+	_, errHeader := w.Write(headerBuf)
+	if errHeader != nil {
+		return errHeader
 	}
 
-	// Write 80 bytes zero header, which is always ignored
-	wr(make([]byte, 80))
-
-	// Number of triangles
-	bwr(uint32(len(t)))
-
-	for _, tr := range t {
-		if err != nil {
-			return err
+	// Write each triangle
+	for _, t := range t {
+		tErr := writeTriangleBinary(w, &t)
+		if tErr != nil {
+			return tErr
 		}
-		pwr(tr.N)
-		pwr(tr.V[0])
-		pwr(tr.V[1])
-		pwr(tr.V[2])
-		wr(twoZeroes)
 	}
 
+	return nil
+}
+
+func writeTriangleBinary(w io.Writer, t *Triangle) error {
+	buf := make([]byte, 50)
+	offset := 0
+	encodePoint(buf, &offset, &t.N)
+	encodePoint(buf, &offset, &t.V[0])
+	encodePoint(buf, &offset, &t.V[1])
+	encodePoint(buf, &offset, &t.V[2])
+	encodeUint16(buf, &offset, 0)
+	_, err := w.Write(buf)
 	return err
+}
+
+func encodePoint(buf []byte, offset *int, pt *Point) {
+	encodeFloat32(buf, offset, pt[0])
+	encodeFloat32(buf, offset, pt[1])
+	encodeFloat32(buf, offset, pt[2])
+}
+
+func encodeFloat32(buf []byte, offset *int, f float32) {
+	u32 := math.Float32bits(f)
+	binary.LittleEndian.PutUint32(buf[*offset:(*offset)+4], u32)
+	(*offset) += 4
+}
+
+func encodeUint16(buf []byte, offset *int, u uint16) {
+	binary.LittleEndian.PutUint16(buf[*offset:(*offset)+2], u)
+	(*offset) += 2
 }


### PR DESCRIPTION
I merged some write code from hschendel/stl which uses binary.LittleEndian interface which reduces write time to half. Increasing the buffer size to hold max of 512 triangles give three orders of magnitude improvement for really large files.
